### PR TITLE
some additional features

### DIFF
--- a/lib/Data/TableReader.pm
+++ b/lib/Data/TableReader.pm
@@ -372,14 +372,7 @@ or is installed; it might just echo the file extension back to you.
 
 sub detect_input_format {
 	my ($self, $filename, $magic)= @_;
-	# Detect filename if not supplied
-	if (!defined $filename) {
-		my $input= $self->input;
-		$filename= '';
-		$filename= "$input" if defined $input and (!ref $input || ref($input) =~ /path|file/i);
-	}
-	my ($suffix)= ($filename =~ /\.([^.]+)$/);
-	$suffix= defined $suffix? uc($suffix) : '';
+
 	# Load first block of file, unless supplied
 	my $fpos;
 	if (!defined $magic) {
@@ -409,6 +402,16 @@ sub detect_input_format {
 
 	# Else trust the file extension, because TSV with commas can be very similar to CSV with
 	# tabs in the data.
+    my $suffix = do {
+        # Detect filename if not supplied
+        if (!defined $filename) {
+            my $input= $self->input;
+            $filename= '';
+            $filename= "$input" if defined $input and (!ref $input || ref($input) =~ /path|file/i);
+        }
+        my ($suffix)= ($filename =~ /\.([^.]+)$/);
+        defined $suffix? uc($suffix) : '';
+    };
 	return $suffix if length $suffix;
 
 	# Else probe some more...

--- a/lib/Data/TableReader.pm
+++ b/lib/Data/TableReader.pm
@@ -262,29 +262,30 @@ sub _build__file_handle {
 sub _build_decoder {
 	my $self= shift;
 	my $decoder_arg= $self->_decoder_arg;
+	my $decoder_ref= ref $decoder_arg;
 	my ($class, @args);
 	if (!$decoder_arg) {
 		($class, @args)= $self->detect_input_format;
 		$self->_log->('trace', "Detected input format as %s", $class);
 	}
-	elsif (!ref $decoder_arg) {
+	elsif (!$decoder_ref) {
 		$class= $decoder_arg;
 	}
-	elsif (ref $decoder_arg eq 'HASH') {
+	elsif ($decoder_ref eq 'HASH') {
 		my %tmp= %$decoder_arg;
 		$class= delete $tmp{CLASS};
 		($class, @args)= $self->detect_input_format if !$class;
 		croak "require ->{CLASS} in decoder arguments" if !$class;
 		@args= (@args, %tmp);
 	}
-	elsif (ref $decoder_arg eq 'ARRAY') {
+	elsif ($decoder_ref eq 'ARRAY') {
 		($class, @args)= @$decoder_arg;
 	}
-	elsif (ref($decoder_arg)->can('iterator')) {
+	elsif ($decoder_ref->can('iterator')) {
 		return $decoder_arg;
 	}
 	else {
-		croak "Can't create decoder from ".ref($decoder_arg);
+		croak "Can't create decoder from $decoder_ref";
 	}
 	$class= "Data::TableReader::Decoder::$class"
 		unless $class =~ /::/;

--- a/lib/Data/TableReader.pm
+++ b/lib/Data/TableReader.pm
@@ -272,10 +272,10 @@ sub _build_decoder {
 	}
 	elsif (ref $decoder_arg eq 'HASH') {
 		my %tmp= %$decoder_arg;
-		$class= delete $tmp{CLASS}
-			or ($class)= $self->detect_input_format
-			or croak "require ->{CLASS} in decoder arguments";
-		@args= %tmp;
+		$class= delete $tmp{CLASS};
+		($class, @args)= $self->detect_input_format if !$class;
+		croak "require ->{CLASS} in decoder arguments" if !$class;
+		@args= (@args, %tmp);
 	}
 	elsif (ref $decoder_arg eq 'ARRAY') {
 		($class, @args)= @$decoder_arg;

--- a/lib/Data/TableReader/Decoder/Spreadsheet.pm
+++ b/lib/Data/TableReader/Decoder/Spreadsheet.pm
@@ -23,18 +23,26 @@ This is an instance of L<Spreadsheet::ParseExcel>, L<Spreadsheet::ParseXLSX>,
 or L<Spreadsheet::XLSX> (which all happen have the same API).  Subclasses can
 lazy-build this from the C<file_handle>.
 
-=cut
-
-has workbook => ( is => 'lazy' );
-
 =head2 sheet
 
 This is either a sheet name, a regex for matching a sheet name, or a parser's
 worksheet object.  It is also optional; if not set, all sheets will be iterated.
 
+=head2 xls_formatter
+
+An optional object that is passed to Excel parsers L<Spreadsheet::ParseXLSX> and
+L<Spreadsheet::ParseExcel>. It governs how raw data in cells is formatted into
+values depending on the type of the cell. The parsers create one of their own if
+none is provided, usually L<Spreadsheet::ParseExcel::FmtDefault>.
+
+Note that it does not work for Spreadsheet::XLSX, which hardcodes the formatter
+as Spreadsheet::XLSX::Fmt2007.
+
 =cut
 
+has workbook => ( is => 'lazy' );
 has sheet => ( is => 'ro' );
+has xls_formatter => ( is => 'rw' );
 
 # Arrayref of all sheets we can search
 has _sheets => ( is => 'lazy' );

--- a/lib/Data/TableReader/Decoder/Spreadsheet.pm
+++ b/lib/Data/TableReader/Decoder/Spreadsheet.pm
@@ -65,12 +65,20 @@ sub _build__sheets {
 	return \@sheets;
 }
 
+sub _oo_rowmax_fix {    # openoffice saves bogus rowmax, try and fix
+    my ($s, $rowmax)= @_;
+    my $final_row_max= ($s and ref $s->{Cells} eq "ARRAY" and $#{$s->{Cells}} < $rowmax)    #
+      ? $#{$s->{Cells}} : $rowmax;
+    return $final_row_max;
+}
+
 sub iterator {
 	my $self= shift;
 	my $sheets= $self->_sheets;
 	my $sheet= $sheets->[0];
 	my ($colmin, $colmax)= $sheet? $sheet->col_range() : (0,-1);
 	my ($rowmin, $rowmax)= $sheet? $sheet->row_range() : (0,-1);
+	$rowmax= _oo_rowmax_fix $sheet, $rowmax;
 	my $row= $rowmin-1;
 	Data::TableReader::Decoder::Spreadsheet::_Iter->new(
 		sub {
@@ -130,6 +138,7 @@ sub Data::TableReader::Decoder::Spreadsheet::_Iter::seek {
 	my $sheet= $f->{sheets}[$sheet_idx];
 	my ($colmin, $colmax)= $sheet? $sheet->col_range() : (0,-1);
 	my ($rowmin, $rowmax)= $sheet? $sheet->row_range() : (0,-1);
+	$rowmax= _oo_rowmax_fix $sheet, $rowmax;
 	$row= $rowmin-1 unless defined $row;
 	$f->{sheet_idx}= $sheet_idx;
 	${$f->{sheet_ref}}= $sheet;

--- a/lib/Data/TableReader/Decoder/XLS.pm
+++ b/lib/Data/TableReader/Decoder/XLS.pm
@@ -40,7 +40,7 @@ sub _build_workbook {
 	if (ref $f and ref($f)->can('worksheets')) {
 		$wbook= $f;
 	} else {
-		$wbook= $self->default_xls_module->new->parse($f);
+		$wbook= $self->default_xls_module->new->parse($f, $self->xls_formatter);
 	}
 	defined $wbook or croak "Can't parse file '".$self->file_name."'";
 	return $wbook;

--- a/lib/Data/TableReader/Decoder/XLSX.pm
+++ b/lib/Data/TableReader/Decoder/XLSX.pm
@@ -46,7 +46,7 @@ sub _build_workbook {
 		if ($class->isa('Spreadsheet::XLSX')) {
 			$wbook= $class->new($f);
 		} else {
-			$wbook= $class->new->parse($f);
+			$wbook= $class->new->parse($f, $self->xls_formatter);
 		}
 	}
 	defined $wbook or croak "Can't parse file '".$self->file_name."'";


### PR DESCRIPTION
This contains a number of improvements:

  - a bugfix that prevents openoffice spreadsheets from taking forever to process
  - the input attribute will now take a Spreadsheet::ParseExcel::Worksheet object
  - the arguments in the decoder attribute will now be combined with the args generated by `detect_input_format` if there's no class specified
  - the above behavior is applied to both hashref and arrayref decoder arguments
  - add api to pass XLS formatter object to compatible excel parsers if provided to the decoder